### PR TITLE
Fixes bug where --many and --many-pairs were being ignored

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -26,7 +26,7 @@
 
   options = _.pick(program, 'engine', 'namespaced', 'fullyNamespaced', 'newerThan', 'force', 'fast', 'key', 'verbose');
 
-  many = options.many || options.manyPairs;
+  many = program.many || program.manyPairs;
 
   root = (many != null ? many.constructor : void 0) === String ? many : null;
 

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -60,7 +60,7 @@ options = _.pick program,
     'key'
     'verbose'
 
-many = options.many or options.manyPairs
+many = program.many or program.manyPairs
 root = if many?.constructor is String then many else null
 
 _.extend options, 


### PR DESCRIPTION
The code was trying to pull `many` and `manyPairs` off of the `options` object before they'd actually been copied onto that object.